### PR TITLE
Fixed calculating buttons position when input in rangeSelector is disabled

### DIFF
--- a/js/annotations.js
+++ b/js/annotations.js
@@ -416,7 +416,7 @@ function renderButtons(chart) {
 
 function renderButton(chart, button, i) {
 	var userOffset = chart.annotations.options.buttonsOffsets,
-		xOffset = chart.rangeSelector ? chart.rangeSelector.inputGroup.offset : 0,
+		xOffset = chart.rangeSelector && chart.rangeSelector.options.inputEnabled ? chart.rangeSelector.inputGroup.offset : 0,
 		renderer = chart.renderer,
 		symbol = button.symbol,
 		offset = 30,

--- a/js/annotations.js
+++ b/js/annotations.js
@@ -978,7 +978,7 @@ extend(Chart.prototype, {
 										annotation.redraw();
 								});
 								each(chart.annotations.buttons, function(button, i) {
-										var	xOffset = chart.rangeSelector ? chart.rangeSelector.inputGroup.offset : 0,
+										var	xOffset = chart.rangeSelector && chart.rangeSelector.options.inputEnabled ? chart.rangeSelector.inputGroup.offset : 0,
 												x = chart.plotWidth + chart.plotLeft - ((i+1) * 30) - xOffset - userOffset[0];
 										button[0].attr({
 												x: x


### PR DESCRIPTION
If input in rangeSelector is disabled:

```
rangeSelector: {
    inputEnabled: false,
    ...
}
```

Then you get:
> TypeError: Cannot read property 'offset' of undefined